### PR TITLE
Fixed npm ignore functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = (ignorePath, searchSubdirectories) => {
 
         return promise.then((filename) => {
           let contents = fs.readFileSync(filename).toString();
-          if (ignorePath) {
+          if (ignorePath === true) {
             contents = '.*.swp\n'
                 + '._*\n'
                 + '.DS_Store\n'
@@ -57,6 +57,8 @@ module.exports = (ignorePath, searchSubdirectories) => {
                 + 'CVS\n'
                 + 'npm-debug.log\n'
                 + 'node_modules\n'
+                + '.gitignore\n'
+                + '.npmignore\n'
                 + contents;
           }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ls-ignore",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "(Node.js) Command line utility for checking what files are ignored by .gitignore and .npmignore files",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/bytesnz/ls-ignore#readme",
   "dependencies": {
     "glob": "^7.1.2",
-    "ignore": "^3.3.5",
+    "ignore": "^3.3.7",
     "minimist": "^1.2.0",
     "pkg-dir": "^2.0.0"
   }


### PR DESCRIPTION
Fixes #1 
- Added .gitignore and .npmignore to ignore list
- Ensure that npm ignore list is only added when `-n` specified